### PR TITLE
fix: missed handling for player disconnects

### DIFF
--- a/addons/offload/fnc_handleDisconnect.sqf
+++ b/addons/offload/fnc_handleDisconnect.sqf
@@ -23,7 +23,7 @@ if (GVAR(DebugMode) > 0) then {
 };
 
 GVAR(ProcessingDisconnect) = true;// global flag
-INFO('ProcessingDisconnect set');
+INFO_1('ProcessingDisconnect set : %1', _name);
 
 if (_unit in GVAR(HeadlessArray)) exitWith {
 	_index = GVAR(HeadlessArray) find _unit;
@@ -80,3 +80,7 @@ if (_unit in GVAR(ZeusArray)) exitWith {
 	INFO('ProcessingDisconnect unset');
 	GVAR(ProcessingDisconnect) = false;
 };
+
+// unflag if normal player
+INFO('ProcessingDisconnect unset');
+GVAR(ProcessingDisconnect) = false;

--- a/addons/offload/fnc_transfer.sqf
+++ b/addons/offload/fnc_transfer.sqf
@@ -37,7 +37,7 @@ INFO_1("Started Transferring for %1 groups", count _groupArray);
 
 {
 	waitUntil {
-		sleep 0.1;
+		sleep 0.5;
 		!GVAR(ProcessingDisconnect)
 	};
 	if (GVAR(EmergencyTransferring)) exitWith {
@@ -45,7 +45,7 @@ INFO_1("Started Transferring for %1 groups", count _groupArray);
 		WARNING("Stopping Transferring due to emergency dump");
 	};
 	waitUntil {
-		sleep 0.1;
+		sleep 0.5;
 		!GVAR(FastTransferring)
 	};
 
@@ -148,7 +148,7 @@ INFO_1("Started Transferring for %1 groups", count _groupArray);
 	};
 
 	waitUntil {
-		sleep 0.1;
+		sleep 0.5;
 		!GVAR(ProcessingDisconnect)
 	};
 

--- a/addons/offload/fnc_zeusTransfer.sqf
+++ b/addons/offload/fnc_zeusTransfer.sqf
@@ -83,7 +83,7 @@ INFO('FastTransferring set');
 	};
 
 	waitUntil {
-		sleep 0.1;
+		sleep 0.5;
 		!GVAR(ProcessingDisconnect)
 	};// prevent some desync issues
 


### PR DESCRIPTION
Missed unflagging processing disconnect when a normal player disconnects.  Resulting in the offload loop hanging due to the flag not being unset properly.

I am a dumb

Some reduction it waituntil checking frequency too.

